### PR TITLE
Remove lingering switch permissions when a user leaves a team

### DIFF
--- a/ap_src/ap_app/static/js/teams.js
+++ b/ap_src/ap_app/static/js/teams.js
@@ -56,7 +56,7 @@ function favouriteTeam(e, user, id) {
 /*
 Leaves team but also checks for lingering permissions and removes them
 */
-async function LeaveTeam(e, user, token) {
+async function LeaveTeamAndRemovePermissions(e, user, token) {
     const headers = {
       "Content-Type": "application/json",
       "X-CSRFToken": token,

--- a/ap_src/ap_app/static/js/teams.js
+++ b/ap_src/ap_app/static/js/teams.js
@@ -53,40 +53,44 @@ function favouriteTeam(e, user, id) {
     })
 }
 
-function LeaveTeam(e, user, redirect, token) {
-    var data = JSON.stringify({"username": user, "team": e.id})
-    console.log("Fetching leave response... jksaodklasjdk")
-    fetch(apiURL + 'api/manage/?method=leave', {
-        method: "post",
-        body: data,
-        headers: {
-            "Content-Type": "application/json",
-            "X-CSRFToken": token
+async function LeaveTeam(e, user, token) {
+    const headers = {
+      "Content-Type": "application/json",
+      "X-CSRFToken": token,
+    };
+  
+    var data = JSON.stringify({ username: user, team: e.id });
+  
+    const leaveResponse = await fetch(apiURL + "api/manage/?method=leave", {
+      method: "post",
+      body: data,
+      headers: headers,
+    });
+  
+    if (!leaveResponse.ok)
+      throw new Error(`Leave request failed with status ${leaveResponse.status}`);
+  
+    const leaveData = await leaveResponse.json();
+  
+    if (leaveData.message === "success") {
+      const permissionsResponse = await fetch(
+        window.location.origin + "/lingering_perms_check",
+        {
+          method: "post",
+          body: data,
+          headers: headers,
         },
-    })
-    .then(() => {
-        console.log("Response is OK. jksaodklasjdk")
-        if (redirect) {
-            console.log("Response is OK. jksaodklasjdk Redirecting")
-            var response = fetch(window.location.origin + "/lingering_perms_check", {
-                method: "post",
-                body: data,
-                headers: {
-                    "Content-Type": "application/json",
-                    "X-CSRFToken": token
-                },
-            })
-            .then(() => {console.log(response)})
-            location.replace(location.origin + "/teams")
-        } else {
-            console.log("Response is OK. jksaodklasjdk Reloading")
-            location.reload()
-        }
-    })
-    .catch(err => {
-        console.log(err)
-    })
-}
+      );
+  
+      if (!permissionsResponse.ok)
+        throw new Error(
+          `Permissions check request failed with status ${permissionsResponse.status}`,
+        );
+  
+      const permissionsData = await permissionsResponse.json();
+      location.replace(location.origin + "/teams")
+    }
+  }
 
 function DeleteTeam(e) {
     var data = JSON.stringify({"id": e.id})

--- a/ap_src/ap_app/static/js/teams.js
+++ b/ap_src/ap_app/static/js/teams.js
@@ -53,6 +53,9 @@ function favouriteTeam(e, user, id) {
     })
 }
 
+/*
+Leaves team but also checks for lingering permissions and removes them
+*/
 async function LeaveTeam(e, user, token) {
     const headers = {
       "Content-Type": "application/json",

--- a/ap_src/ap_app/static/js/teams.js
+++ b/ap_src/ap_app/static/js/teams.js
@@ -79,7 +79,7 @@ async function LeaveTeamAndRemovePermissions(e, username, token) {
       const permissionsResponse = await fetch(
         window.location.origin + "/remove_lingering_perms",
         {
-          method: "post",
+          method: "get",
           headers: headers,
         },
       );

--- a/ap_src/ap_app/static/js/teams.js
+++ b/ap_src/ap_app/static/js/teams.js
@@ -80,7 +80,6 @@ async function LeaveTeamAndRemovePermissions(e, user, token) {
         window.location.origin + "/remove_lingering_perms",
         {
           method: "post",
-          body: data,
           headers: headers,
         },
       );

--- a/ap_src/ap_app/static/js/teams.js
+++ b/ap_src/ap_app/static/js/teams.js
@@ -74,7 +74,7 @@ async function LeaveTeam(e, user, token) {
   
     if (leaveData.message === "success") {
       const permissionsResponse = await fetch(
-        window.location.origin + "/lingering_perms_check",
+        window.location.origin + "/remove_lingering_perms",
         {
           method: "post",
           body: data,

--- a/ap_src/ap_app/static/js/teams.js
+++ b/ap_src/ap_app/static/js/teams.js
@@ -56,13 +56,13 @@ function favouriteTeam(e, user, id) {
 /*
 Leaves team but also checks for lingering permissions and removes them
 */
-async function LeaveTeamAndRemovePermissions(e, user, token) {
+async function LeaveTeamAndRemovePermissions(e, username, token) {
     const headers = {
       "Content-Type": "application/json",
       "X-CSRFToken": token,
     };
   
-    var data = JSON.stringify({ username: user, team: e.id });
+    var data = JSON.stringify({ username: username, team: e.id });
   
     const leaveResponse = await fetch(apiURL + "api/manage/?method=leave", {
       method: "post",

--- a/ap_src/ap_app/static/js/teams.js
+++ b/ap_src/ap_app/static/js/teams.js
@@ -53,39 +53,33 @@ function favouriteTeam(e, user, id) {
     })
 }
 
-function LeaveTeam(e, user, redirect) {
+function LeaveTeam(e, user, redirect, token) {
     var data = JSON.stringify({"username": user, "team": e.id})
-    var response = fetch(apiURL + 'api/manage/?method=leave', {
+    console.log("Fetching leave response... jksaodklasjdk")
+    fetch(apiURL + 'api/manage/?method=leave', {
         method: "post",
         body: data,
         headers: {
             "Content-Type": "application/json",
+            "X-CSRFToken": token
         },
     })
     .then(() => {
-        if (response.ok) {
-            console.log("Response is OK. jksaodklasjdk")
-            $.ajax({
-                url: '/lingering_perms_check/',
-                type: 'POST',
-                data: {
-                    'id': itemId,
-                },
-                success: function(response) {
-                    if (response.status === 'success') {
-                        alert('Lingering permissions removed!');
-                    } else {
-                        alert('Failed to remove lingering permissions: ' + response.message);
-                    }
-                },
-                error: function(xhr, status, error) {
-                    alert('An error occurred: ' + error);
-                }
-            });
-        }
+        console.log("Response is OK. jksaodklasjdk")
         if (redirect) {
+            console.log("Response is OK. jksaodklasjdk Redirecting")
+            var response = fetch(window.location.origin + "/lingering_perms_check", {
+                method: "post",
+                body: data,
+                headers: {
+                    "Content-Type": "application/json",
+                    "X-CSRFToken": token
+                },
+            })
+            .then(() => {console.log(response)})
             location.replace(location.origin + "/teams")
         } else {
+            console.log("Response is OK. jksaodklasjdk Reloading")
             location.reload()
         }
     })

--- a/ap_src/ap_app/static/js/teams.js
+++ b/ap_src/ap_app/static/js/teams.js
@@ -55,7 +55,7 @@ function favouriteTeam(e, user, id) {
 
 function LeaveTeam(e, user, redirect) {
     var data = JSON.stringify({"username": user, "team": e.id})
-    fetch(apiURL + 'api/manage/?method=leave', {
+    var response = fetch(apiURL + 'api/manage/?method=leave', {
         method: "post",
         body: data,
         headers: {
@@ -63,6 +63,26 @@ function LeaveTeam(e, user, redirect) {
         },
     })
     .then(() => {
+        if (response.ok) {
+            console.log("Response is OK. jksaodklasjdk")
+            $.ajax({
+                url: '/lingering_perms_check/',
+                type: 'POST',
+                data: {
+                    'id': itemId,
+                },
+                success: function(response) {
+                    if (response.status === 'success') {
+                        alert('Lingering permissions removed!');
+                    } else {
+                        alert('Failed to remove lingering permissions: ' + response.message);
+                    }
+                },
+                error: function(xhr, status, error) {
+                    alert('An error occurred: ' + error);
+                }
+            });
+        }
         if (redirect) {
             location.replace(location.origin + "/teams")
         } else {

--- a/ap_src/ap_app/urls.py
+++ b/ap_src/ap_app/urls.py
@@ -52,7 +52,7 @@ urlpatterns = [
     path("calendar/set_month",views.set_calendar_month, name="set_month"),
     path("main_calendar", views.main_calendar, name="main_calendar"),
     path("main_calendar/<str:month>/<int:year>", views.main_calendar, name="main_calendar"),
-    path("lingering_perms_check", views.lingering_perms_check, name="lingering_perms_check"),
+    path("remove_lingering_perms", views.remove_lingering_perms, name="remove_lingering_perms"),
     re_path(r'^static/(?P<path>.*)$', serve,{'document_root': settings.STATIC_ROOT}) #This lets Django find the CSS files when debug is set to false
 
 ] 

--- a/ap_src/ap_app/urls.py
+++ b/ap_src/ap_app/urls.py
@@ -52,7 +52,7 @@ urlpatterns = [
     path("calendar/set_month",views.set_calendar_month, name="set_month"),
     path("main_calendar", views.main_calendar, name="main_calendar"),
     path("main_calendar/<str:month>/<int:year>", views.main_calendar, name="main_calendar"),
-    path("lingering_perms_check/", views.lingering_perms_check, name="lingering_perms_check"),
+    path("lingering_perms_check", views.lingering_perms_check, name="lingering_perms_check"),
     re_path(r'^static/(?P<path>.*)$', serve,{'document_root': settings.STATIC_ROOT}) #This lets Django find the CSS files when debug is set to false
 
 ] 

--- a/ap_src/ap_app/urls.py
+++ b/ap_src/ap_app/urls.py
@@ -52,6 +52,7 @@ urlpatterns = [
     path("calendar/set_month",views.set_calendar_month, name="set_month"),
     path("main_calendar", views.main_calendar, name="main_calendar"),
     path("main_calendar/<str:month>/<int:year>", views.main_calendar, name="main_calendar"),
+    path("lingering_perms_check/", views.lingering_perms_check, name="lingering_perms_check"),
     re_path(r'^static/(?P<path>.*)$', serve,{'document_root': settings.STATIC_ROOT}) #This lets Django find the CSS files when debug is set to false
 
 ] 

--- a/ap_src/ap_app/utils/switch_permissions.py
+++ b/ap_src/ap_app/utils/switch_permissions.py
@@ -94,6 +94,7 @@ def process_user_usernames(selected_username, usernames_given_permissions, users
             if action is None:
                 return
             return NO_ERRORS
+    return NO_ERRORS
 
 def process_userprofile_usernames(selected_username, userprofile_usernames_who_give_permissions, users_sharing_teams, action):
     """
@@ -120,6 +121,7 @@ def process_userprofile_usernames(selected_username, userprofile_usernames_who_g
             if action is None:
                 return
             return NO_ERRORS
+    return NO_ERRORS
 
 def remove_switch_permissions(userprofile_id, user_id):
     """

--- a/ap_src/ap_app/utils/switch_permissions.py
+++ b/ap_src/ap_app/utils/switch_permissions.py
@@ -4,8 +4,6 @@ from django.contrib.auth.models import User
 from .teams_utils import get_users_sharing_teams
 from .user_profile import get_user_id_from_username, get_userprofile_id_from_user_id
 
-NO_ERRORS = True
-
 def check_for_lingering_switch_perms(username, action):
     """
     Check that discovers lingering switch permissions in the database and determines what to do with them.
@@ -18,6 +16,8 @@ def check_for_lingering_switch_perms(username, action):
     - `username` (`str`): Username of the user who left the team.
     - `action`: Function that is executed when redundant permissions (lingering switch perms) are discovered.
     """
+
+    NO_ERRORS = True
 
     user_id = get_user_id_from_username(username)
     userprofile_id = get_userprofile_id_from_user_id(user_id)
@@ -79,6 +79,9 @@ def process_user_usernames(selected_username, usernames_given_permissions, users
     - `users_sharing_teams`: List of unique usernames sharing teams with the user.
     - `action`: Function that is executed when redundant permissions are found in the list.
     """
+
+    NO_ERRORS = True
+
     selected_user_id = get_user_id_from_username(selected_username)
     selected_userprofile_id = get_userprofile_id_from_user_id(selected_user_id)
     if (selected_user_id is None) or (selected_userprofile_id is None):
@@ -106,6 +109,9 @@ def process_userprofile_usernames(selected_username, userprofile_usernames_who_g
     - `users_sharing_teams`: List of unique usernames sharing teams with the user.
     - `action`: Function that is executed when redundant permissions are found in the list.
     """
+
+    NO_ERRORS = True
+
     selected_user_id = get_user_id_from_username(selected_username)
     if selected_user_id is None:
         print("User ID does not exist in absence planner database")
@@ -131,6 +137,8 @@ def remove_switch_permissions(userprofile_id, user_id):
     - `userprofile_id`: The ID of the user who has given permissions.
     - `user_id`: The ID of the user whose permissions will be removed.
     """
+
+    NO_ERRORS = True
 
     # Get instance of UserProfile that matches given ID
     try:

--- a/ap_src/ap_app/views.py
+++ b/ap_src/ap_app/views.py
@@ -472,9 +472,15 @@ def click_remove(request):
 
 @login_required
 def remove_lingering_perms(request):
+    """
+    Removes lingering switch permissions associated with the user who made the `request`.
+
+    Generally ran when a user leaves a team and we wish to remove any lingering permissions.
+    """
     if request.method == "POST":
         username = request.user.get_username()
         result = check_for_lingering_switch_perms(username, remove_switch_permissions)
         if result is not None:
             return JsonResponse({'status': 'success'})
+    # Something failed in the logic for checking and removing switch permissions
     return JsonResponse({'status': 'fail', 'message': 'Invalid request'})

--- a/ap_src/ap_app/views.py
+++ b/ap_src/ap_app/views.py
@@ -40,6 +40,8 @@ from .forms import *
 from .models import (Absence, RecurringAbsences, Relationship, Role, Team,
                      UserProfile, ColourScheme, ColorData)
 
+from .utils.switch_permissions import check_for_lingering_switch_perms, remove_switch_permissions
+
 User = get_user_model()
 
 
@@ -467,3 +469,14 @@ def click_remove(request):
         return JsonResponse({"start_date": data["date"]})
     else:
         return HttpResponse("404")
+
+@login_required
+def lingering_perms_check(request):
+    print("Request for lingering_perms_check:", request)
+    if request.method == "POST":
+        username = request.POST.get("id")
+        print("Username of user leaving team:", username)
+        result = check_for_lingering_switch_perms(username, remove_switch_permissions)
+        if result is not None:
+            return JsonResponse({'status': 'success'})
+    return JsonResponse({'status': 'fail', 'message': 'Invalid request'})

--- a/ap_src/ap_app/views.py
+++ b/ap_src/ap_app/views.py
@@ -473,7 +473,7 @@ def click_remove(request):
 @login_required
 def lingering_perms_check(request):
     if request.method == "POST":
-        username = request.POST.get("id")
+        username = request.user.get_username()
         result = check_for_lingering_switch_perms(username, remove_switch_permissions)
         if result is not None:
             return JsonResponse({'status': 'success'})

--- a/ap_src/ap_app/views.py
+++ b/ap_src/ap_app/views.py
@@ -472,10 +472,8 @@ def click_remove(request):
 
 @login_required
 def lingering_perms_check(request):
-    print("Request for lingering_perms_check:", request)
     if request.method == "POST":
         username = request.POST.get("id")
-        print("Username of user leaving team:", username)
         result = check_for_lingering_switch_perms(username, remove_switch_permissions)
         if result is not None:
             return JsonResponse({'status': 'success'})

--- a/ap_src/ap_app/views.py
+++ b/ap_src/ap_app/views.py
@@ -471,7 +471,7 @@ def click_remove(request):
         return HttpResponse("404")
 
 @login_required
-def lingering_perms_check(request):
+def remove_lingering_perms(request):
     if request.method == "POST":
         username = request.user.get_username()
         result = check_for_lingering_switch_perms(username, remove_switch_permissions)

--- a/ap_src/templates/api_pages/team_calendar.html
+++ b/ap_src/templates/api_pages/team_calendar.html
@@ -44,7 +44,7 @@
                 {% if user_data.role_info.role == "Owner" or user_data.role_info.role == "Co-Owner" %}
                 <a class="button is-link is-outlined mx-1" title="Settings" href={% url 'edit_team' id=team.id %}><i class="fas fa-cog"></i></a>
                 {% endif %}
-                <button class="button is-danger is-outlined mx-1" title="Leave" onclick="LeaveTeam(this, '{{ request.user.username }}', true)", id="{{ team.id }}">Leave</button>
+                <button class="button is-danger mx-1" id="{{ team.id }}" onclick="LeaveTeam(this, '{{ request.user.username }}', '{{ csrf_token }}')">Leave</button>
             </div>
 
         </div>

--- a/ap_src/templates/api_pages/team_calendar.html
+++ b/ap_src/templates/api_pages/team_calendar.html
@@ -44,7 +44,7 @@
                 {% if user_data.role_info.role == "Owner" or user_data.role_info.role == "Co-Owner" %}
                 <a class="button is-link is-outlined mx-1" title="Settings" href={% url 'edit_team' id=team.id %}><i class="fas fa-cog"></i></a>
                 {% endif %}
-                <button class="button is-danger mx-1" title="Leave" id="{{ team.id }}" onclick="LeaveTeam(this, '{{ request.user.username }}', '{{ csrf_token }}')">Leave</button>
+                <button class="button is-danger mx-1" title="Leave" id="{{ team.id }}" onclick="LeaveTeamAndRemovePermissions(this, '{{ request.user.username }}', '{{ csrf_token }}')">Leave</button>
             </div>
 
         </div>

--- a/ap_src/templates/api_pages/team_calendar.html
+++ b/ap_src/templates/api_pages/team_calendar.html
@@ -44,7 +44,7 @@
                 {% if user_data.role_info.role == "Owner" or user_data.role_info.role == "Co-Owner" %}
                 <a class="button is-link is-outlined mx-1" title="Settings" href={% url 'edit_team' id=team.id %}><i class="fas fa-cog"></i></a>
                 {% endif %}
-                <button class="button is-danger mx-1" id="{{ team.id }}" onclick="LeaveTeam(this, '{{ request.user.username }}', '{{ csrf_token }}')">Leave</button>
+                <button class="button is-danger mx-1" title="Leave" id="{{ team.id }}" onclick="LeaveTeam(this, '{{ request.user.username }}', '{{ csrf_token }}')">Leave</button>
             </div>
 
         </div>

--- a/ap_src/templates/teams/dashboard.html
+++ b/ap_src/templates/teams/dashboard.html
@@ -116,7 +116,7 @@
             {% if team.role.role == "Owner" or team.role.role == "Co-Owner"%}
             <a class="button is-info mx-1" href={% url 'edit_team' id=team.team.id %}>Edit</a>
             {% endif %}
-            <button class="button is-danger mx-1" id="{{ team.team.id }}" onclick="LeaveTeam(this, '{{ request.user.username }}', '{{ csrf_token }}')">Leave</button>
+            <button class="button is-danger mx-1" title="Leave" id="{{ team.team.id }}" onclick="LeaveTeam(this, '{{ request.user.username }}', '{{ csrf_token }}')">Leave</button>
         </div>
     </div>
     {% endfor %}

--- a/ap_src/templates/teams/dashboard.html
+++ b/ap_src/templates/teams/dashboard.html
@@ -123,5 +123,5 @@
     {% endif %}
     
 </div>
-<script src="{% static 'js/teams.js' %}" apiURL="{{ url }}" token="{{ csrf_token }}"></script>
+<script src="{% static 'js/teams.js' %}" apiURL="{{ url }}"></script>
 {% endblock %}

--- a/ap_src/templates/teams/dashboard.html
+++ b/ap_src/templates/teams/dashboard.html
@@ -116,7 +116,7 @@
             {% if team.role.role == "Owner" or team.role.role == "Co-Owner"%}
             <a class="button is-info mx-1" href={% url 'edit_team' id=team.team.id %}>Edit</a>
             {% endif %}
-            <button class="button is-danger mx-1" id="{{ team.team.id }}" onclick="LeaveTeam(this, '{{ request.user.username }}', false, '{{ csrf_token }}')">Leave</button>
+            <button class="button is-danger mx-1" id="{{ team.team.id }}" onclick="LeaveTeam(this, '{{ request.user.username }}', '{{ csrf_token }}')">Leave</button>
         </div>
     </div>
     {% endfor %}

--- a/ap_src/templates/teams/dashboard.html
+++ b/ap_src/templates/teams/dashboard.html
@@ -116,7 +116,7 @@
             {% if team.role.role == "Owner" or team.role.role == "Co-Owner"%}
             <a class="button is-info mx-1" href={% url 'edit_team' id=team.team.id %}>Edit</a>
             {% endif %}
-            <button class="button is-danger mx-1" title="Leave" id="{{ team.team.id }}" onclick="LeaveTeam(this, '{{ request.user.username }}', '{{ csrf_token }}')">Leave</button>
+            <button class="button is-danger mx-1" title="Leave" id="{{ team.team.id }}" onclick="LeaveTeamAndRemovePermissions(this, '{{ request.user.username }}', '{{ csrf_token }}')">Leave</button>
         </div>
     </div>
     {% endfor %}

--- a/ap_src/templates/teams/dashboard.html
+++ b/ap_src/templates/teams/dashboard.html
@@ -116,12 +116,12 @@
             {% if team.role.role == "Owner" or team.role.role == "Co-Owner"%}
             <a class="button is-info mx-1" href={% url 'edit_team' id=team.team.id %}>Edit</a>
             {% endif %}
-            <button class="button is-danger mx-1" id="{{ team.team.id }}" onclick="LeaveTeam(this, '{{ request.user.username }}', false)">Leave</button>
+            <button class="button is-danger mx-1" id="{{ team.team.id }}" onclick="LeaveTeam(this, '{{ request.user.username }}', false, '{{ csrf_token }}')">Leave</button>
         </div>
     </div>
     {% endfor %}
     {% endif %}
     
 </div>
-<script src="{% static 'js/teams.js' %}" apiURL="{{ url }}"></script>
+<script src="{% static 'js/teams.js' %}" apiURL="{{ url }}" token="{{ csrf_token }}"></script>
 {% endblock %}


### PR DESCRIPTION
This should activate when the user leaves a team using both buttons. It will run back-end logic that has already been merged into `develop`.