### PR TITLE
Fix broken switch permission view

### DIFF
--- a/ap_src/ap_app/views.py
+++ b/ap_src/ap_app/views.py
@@ -477,7 +477,7 @@ def remove_lingering_perms(request):
 
     Generally ran when a user leaves a team and we wish to remove any lingering permissions.
     """
-    if request.method == "POST":
+    if request.method == "GET":
         username = request.user.get_username()
         result = check_for_lingering_switch_perms(username, remove_switch_permissions)
         if result is not None:


### PR DESCRIPTION
The problem was that the `POST` was changed to `GET` but the view logic wasn't changed in accordance with this. It is amended in this branch, which when merged will fix #175.