### PR TITLE
Use full name by default on the calendar, and show extra information on the tooltip

### DIFF
--- a/ap_src/ap_app/static/css/calendar.css
+++ b/ap_src/ap_app/static/css/calendar.css
@@ -1,3 +1,7 @@
+:root {
+    --cell-size: 47px;
+}
+
 .RefreshBox {
     pointer-events: none;
     text-align: right;
@@ -14,8 +18,10 @@
 }
 
 .CalendarCell {
-    min-width: 47px;
-    max-width: 47px;
+    min-width: var(--cell-size);
+    max-width: var(--cell-size);
+    height: var(--cell-size);
+    max-height: var(--cell-size);
 }
 
 .nav-bar-padding {
@@ -85,7 +91,9 @@
 .user-cell {
     width: 6vw; 
     min-width: var(--user-cell-width); 
-    max-width: var(--user-cell-width); 
+    max-width: var(--user-cell-width);
+    height: var(--cell-size);
+    white-space: nowrap;
 }
 
 .username {

--- a/ap_src/templates/calendars/calendar_element.html
+++ b/ap_src/templates/calendars/calendar_element.html
@@ -58,11 +58,23 @@
                         <td class="user-cell selected-user-cell tooltip">
                             <div class="username">
                                 <span class="tooltiptext">
-                                    {{user.first_name}} {{user.last_name}}<br>
+                                    {% if user.first_name == "" and user.last_name == "" %}
+                                        Name: N/A<br>
+                                    {% else %}
+                                        Name: {{user.first_name}} {{user.last_name}}<br>
+                                    {% endif %}
                                     Username: {{user.username}}<br>
-                                    Email: {{user.email}}
+                                    {% if user.first_name == "" and user.last_name == "" %}
+                                        Email: N/A
+                                    {% else %}
+                                        Email: {{user.email}}
+                                    {% endif %}
                                 </span>
-                                {{user.first_name}} {{user.last_name}}
+                                {% if user.first_name != "" and user.last_name != "" %}
+                                    {{user.first_name}} {{user.last_name}}
+                                {% else %}
+                                    {{user.username}}
+                                {% endif %}
                             </div>
                         </td>
                         {% else %}
@@ -70,22 +82,46 @@
                             <td class="user-cell unselected-user-cell tooltip">
                                 <div class="username">
                                     <span class="tooltiptext">
-                                        {{member.user.first_name}} {{member.user.last_name}}*<br>
+                                        {% if member.user.first_name == "" and member.user.last_name == "" %}
+                                            Name: N/A<br>
+                                        {% else %}
+                                            Name: {{user.first_name}} {{user.last_name}}<br>
+                                        {% endif %}
                                         Username: {{member.user.username}}<br>
-                                        Email: {{member.user.email}}
+                                        {% if member.user.first_name == "" and member.user.last_name == "" %}
+                                            Email: N/A
+                                        {% else %}
+                                            Email: {{member.user.email}}
+                                        {% endif %}
                                     </span>
-                                    {{member.user.first_name}} {{member.user.last_name}}*
+                                    {% if member.user.first_name != "" and member.user.last_name != "" %}
+                                        {{member.user.first_name}} {{member.user.last_name}}*
+                                    {% else %}
+                                        {{member.user.username}}*
+                                    {% endif %}
                                 </div>
                             </td>
                             {% else %}
                             <td class="user-cell unselected-user-cell tooltip">
                                 <div class="username">
                                     <span class="tooltiptext">
-                                        {{member.user.first_name}} {{member.user.last_name}}<br>
+                                        {% if member.user.first_name == "" and member.user.last_name == "" %}
+                                            Name: N/A<br>
+                                        {% else %}
+                                            Name: {{user.first_name}} {{user.last_name}}<br>
+                                        {% endif %}
                                         Username: {{member.user.username}}<br>
-                                        Email: {{member.user.email}}
+                                        {% if member.user.first_name == "" and member.user.last_name == "" %}
+                                            Email: N/A
+                                        {% else %}
+                                            Email: {{member.user.email}}
+                                        {% endif %}
                                     </span>
-                                    {{member.user.first_name}} {{member.user.last_name}}
+                                    {% if member.user.first_name != "" and member.user.last_name != "" %}
+                                        {{member.user.first_name}} {{member.user.last_name}}
+                                    {% else %}
+                                        {{member.user.username}}
+                                    {% endif %}
                                 </div>
                             </td>
                             {% endif %}

--- a/ap_src/templates/calendars/calendar_element.html
+++ b/ap_src/templates/calendars/calendar_element.html
@@ -57,23 +57,35 @@
                         {% if member.user.username == user.username %}
                         <td class="user-cell selected-user-cell tooltip">
                             <div class="username">
-                                <span class="tooltiptext">{{user.username}}</span>
-                                {{user.username}}
+                                <span class="tooltiptext">
+                                    {{user.first_name}} {{user.last_name}}<br>
+                                    Username: {{user.username}}<br>
+                                    Email: {{user.email}}
+                                </span>
+                                {{user.first_name}} {{user.last_name}}
                             </div>
                         </td>
                         {% else %}
                             {% if editable %}
                             <td class="user-cell unselected-user-cell tooltip">
                                 <div class="username">
-                                    <span class="tooltiptext">{{member.user.username}}*</span>
-                                    {{member.user.username}}*
+                                    <span class="tooltiptext">
+                                        {{member.user.first_name}} {{member.user.last_name}}*<br>
+                                        Username: {{member.user.username}}<br>
+                                        Email: {{member.user.email}}
+                                    </span>
+                                    {{member.user.first_name}} {{member.user.last_name}}*
                                 </div>
                             </td>
                             {% else %}
                             <td class="user-cell unselected-user-cell tooltip">
                                 <div class="username">
-                                    <span class="tooltiptext">{{member.user.username}}</span>
-                                    {{member.user.username}}
+                                    <span class="tooltiptext">
+                                        {{member.user.first_name}} {{member.user.last_name}}<br>
+                                        Username: {{member.user.username}}<br>
+                                        Email: {{member.user.email}}
+                                    </span>
+                                    {{member.user.first_name}} {{member.user.last_name}}
                                 </div>
                             </td>
                             {% endif %}

--- a/ap_src/templates/calendars/calendar_element.html
+++ b/ap_src/templates/calendars/calendar_element.html
@@ -56,76 +56,15 @@
                     <tr id="{{ member.user.username }}">
                         {% if member.user.username == user.username %}
                         <td class="user-cell selected-user-cell tooltip">
-                            <div class="username">
-                                <span class="tooltiptext">
-                                    {% if user.first_name == "" and user.last_name == "" %}
-                                        Name: N/A<br>
-                                    {% else %}
-                                        Name: {{user.first_name}} {{user.last_name}}<br>
-                                    {% endif %}
-                                    Username: {{user.username}}<br>
-                                    {% if user.first_name == "" and user.last_name == "" %}
-                                        Email: N/A
-                                    {% else %}
-                                        Email: {{user.email}}
-                                    {% endif %}
-                                </span>
-                                {% if user.first_name != "" and user.last_name != "" %}
-                                    {{user.first_name}} {{user.last_name}}
-                                {% else %}
-                                    {{user.username}}
-                                {% endif %}
-                            </div>
-                        </td>
+                            {% include 'calendars/user_info_tooltip.html' %}
                         {% else %}
-                            {% if editable %}
                             <td class="user-cell unselected-user-cell tooltip">
-                                <div class="username">
-                                    <span class="tooltiptext">
-                                        {% if member.user.first_name == "" and member.user.last_name == "" %}
-                                            Name: N/A<br>
-                                        {% else %}
-                                            Name: {{user.first_name}} {{user.last_name}}<br>
-                                        {% endif %}
-                                        Username: {{member.user.username}}<br>
-                                        {% if member.user.first_name == "" and member.user.last_name == "" %}
-                                            Email: N/A
-                                        {% else %}
-                                            Email: {{member.user.email}}
-                                        {% endif %}
-                                    </span>
-                                    {% if member.user.first_name != "" and member.user.last_name != "" %}
-                                        {{member.user.first_name}} {{member.user.last_name}}*
-                                    {% else %}
-                                        {{member.user.username}}*
-                                    {% endif %}
-                                </div>
+                                {% with user=member.user %}
+                                    {% include 'calendars/user_info_tooltip.html' %}
+                                {% endwith %}
                             </td>
-                            {% else %}
-                            <td class="user-cell unselected-user-cell tooltip">
-                                <div class="username">
-                                    <span class="tooltiptext">
-                                        {% if member.user.first_name == "" and member.user.last_name == "" %}
-                                            Name: N/A<br>
-                                        {% else %}
-                                            Name: {{user.first_name}} {{user.last_name}}<br>
-                                        {% endif %}
-                                        Username: {{member.user.username}}<br>
-                                        {% if member.user.first_name == "" and member.user.last_name == "" %}
-                                            Email: N/A
-                                        {% else %}
-                                            Email: {{member.user.email}}
-                                        {% endif %}
-                                    </span>
-                                    {% if member.user.first_name != "" and member.user.last_name != "" %}
-                                        {{member.user.first_name}} {{member.user.last_name}}
-                                    {% else %}
-                                        {{member.user.username}}
-                                    {% endif %}
-                                </div>
-                            </td>
-                            {% endif %}
                         {% endif %}
+                        </td>
 
                         {% for day in day_range %}
 

--- a/ap_src/templates/calendars/user_info_tooltip.html
+++ b/ap_src/templates/calendars/user_info_tooltip.html
@@ -1,15 +1,11 @@
 <div class="username">
     <span class="tooltiptext">
-        {% if user.first_name == "" and user.last_name == "" %}
-            Name: N/A<br>
-        {% else %}
-            Name: {{user.first_name}} {{user.last_name}}<br>
+        {% if user.first_name and user.last_name %}
+            {{user.first_name}} {{user.last_name}}<br>
         {% endif %}
-        Username: {{user.username}}<br>
+        {{user.username}}
         {% if user.email %}
-            Email: N/A
-        {% else %}
-            Email: {{user.email}}
+            <br>{{user.email}}
         {% endif %}
     </span>
     {% if editable %}

--- a/ap_src/templates/calendars/user_info_tooltip.html
+++ b/ap_src/templates/calendars/user_info_tooltip.html
@@ -1,0 +1,23 @@
+<div class="username">
+    <span class="tooltiptext">
+        {% if user.first_name == "" and user.last_name == "" %}
+            Name: N/A<br>
+        {% else %}
+            Name: {{user.first_name}} {{user.last_name}}<br>
+        {% endif %}
+        Username: {{user.username}}<br>
+        {% if user.email %}
+            Email: N/A
+        {% else %}
+            Email: {{user.email}}
+        {% endif %}
+    </span>
+    {% if editable %}
+    *
+    {% endif %}
+    {% if user.first_name and user.last_name %}
+        {{user.first_name}} {{user.last_name}}
+    {% else %}
+        {{user.username}}
+    {% endif %}
+</div>


### PR DESCRIPTION
This PR also fixes some quality issues with the calendar cell sizes, as well as using a single reusable HTML template for user information and associated templating logic.

This should fix issue https://github.com/rropen/absense-planner/issues/332.