### PR TITLE
Add back team calendar

### DIFF
--- a/ap_src/templates/calendars/specific_team_calendar.html
+++ b/ap_src/templates/calendars/specific_team_calendar.html
@@ -70,7 +70,6 @@
     </div>
     <button class="modal-close is-large" aria-label="close"></button>
 </div>
-{% include 'calendars/calendar_element.html'%}
 
 <script src="{% static 'js/teams.js' %}" apiURL="{{ url }}"></script>
 {% endblock %}

--- a/ap_src/templates/calendars/specific_team_calendar.html
+++ b/ap_src/templates/calendars/specific_team_calendar.html
@@ -70,6 +70,7 @@
     </div>
     <button class="modal-close is-large" aria-label="close"></button>
 </div>
+{% include 'calendars/calendar_element.html'%}
 
 <script src="{% static 'js/teams.js' %}" apiURL="{{ url }}"></script>
 {% endblock %}


### PR DESCRIPTION
Add back a calendar that was accidentally removed from the "View Team" page.