### PR TITLE
Changed the text in the join a team page, when the user has joined all available teams

### DIFF
--- a/ap_src/templates/api_pages/teams.html
+++ b/ap_src/templates/api_pages/teams.html
@@ -19,7 +19,7 @@
     {% else %}
         <div class="container has-background-light box">
             <div class="is-size-5 mb-3">
-                <span class="is-block is-size-5">There are no teams currently available.</span>
+                <span class="is-block is-size-5">You've joined all of the available teams.</span>
             </div>
         </div>
     {% endif %}


### PR DESCRIPTION
Just changed the text that shows up when the user has joined all available teams. The previous text was 'There are no teams currently available.' and I changed it to 'You've joined all of the available teams.'
