### PR TITLE
Add external link button for teams

### DIFF
--- a/ap_src/ap_app/static/css/calendar.css
+++ b/ap_src/ap_app/static/css/calendar.css
@@ -110,3 +110,8 @@
     background-color: #0e00d6; 
     color: white; 
 }
+
+.external-link-title {
+    margin-bottom: 10px;
+    gap: 20px;
+}

--- a/ap_src/templates/calendars/calendar_element.html
+++ b/ap_src/templates/calendars/calendar_element.html
@@ -51,7 +51,7 @@
                 <div id="calendar-group">
                     {% for item in team_data %}
                         {% if number_of_teams > 1 %}
-                            <a style="margin-bottom: 10px; gap: 20px;" class="button mx-1" href={% url 'api_team_calendar' id=item.team.id %}>
+                            <a class="button mx-1 external-link-title" href={% url 'api_team_calendar' id=item.team.id %}>
                                 <h1 class="is-size-5 has-text-weight-bold" id="title-{{ item.team.name }}">
                                     {{ item.team.name }}
                                 </h1>

--- a/ap_src/templates/calendars/calendar_element.html
+++ b/ap_src/templates/calendars/calendar_element.html
@@ -45,67 +45,69 @@
                 {% endfor %}
             </thead>
         </table>
-        {% if team_data|length > 0 %}
-        <div id="calendar-group">
-            {% for item in team_data %}
-            <h1 class="is-size-5 has-text-weight-bold" id="title-{{ item.team.name }}">{{ item.team.name }}</h1>
-            <table class="table is-bordered is-striped" style="width: 100%" id="{{ item.team.name }}">
-                <tbody>
-                    {% for member in item.team.members %}
-                    {% check_permissions member request.user as editable %}
-                    <tr id="{{ member.user.username }}">
-                        {% if member.user.username == user.username %}
-                        <td class="user-cell selected-user-cell tooltip">
-                            {% include 'calendars/user_info_tooltip.html' %}
-                        {% else %}
-                            <td class="user-cell unselected-user-cell tooltip">
-                                {% with user=member.user %}
-                                    {% include 'calendars/user_info_tooltip.html' %}
-                                {% endwith %}
-                            </td>
-                        {% endif %}
-                        </td>
 
-                        {% for day in day_range %}
+        {% with team_data|length as number_of_teams %}
+            {% if number_of_teams > 0 %}
+                <div id="calendar-group">
+                    {% for item in team_data %}
+                        <h1 class="is-size-5 has-text-weight-bold" id="title-{{ item.team.name }}">{{ item.team.name }}</h1>
+                        <a class="button is-link mx-1" href={% url 'api_team_calendar' id=item.team.id %}>View</a>
+                        <table class="table is-bordered is-striped" style="width: 100%" id="{{ item.team.name }}">
+                            <tbody>
+                                {% for member in item.team.members %}
+                                    {% check_permissions member request.user as editable %}
+                                    <tr id="{{ member.user.username }}">
+                                        {% if member.user.username == user.username %}
+                                            <td class="user-cell selected-user-cell tooltip">
+                                                {% include 'calendars/user_info_tooltip.html' %}
+                                        {% else %}
+                                            <td class="user-cell unselected-user-cell tooltip">
+                                                {% with user=member.user %}
+                                                    {% include 'calendars/user_info_tooltip.html' %}
+                                                {% endwith %}
+                                            </td>
+                                        {% endif %}
+                                            </td>
 
-                            {% check_absences absence_dates|get_key:member.user.username year month_num day as check_absence %}
-                            {% check_absences recurring_absence_dates|get_key:member.user.username year month_num day as check_recurring_absence %}
-                            {% check_half_day half_days_data|get_key:member.user.username year month_num day as check_half_day %}
-                            {% if check_recurring_absence %}
-                            <td data-editable="{{editable}}" style="background-color: #ffaa00;" class="CalendarCell" id="{{member.user.username}}/{{year}}-{{month_num}}-{{day}}/TRUE" data-absence-type="R"></td>
-                            {% elif check_absence %}
-                            <td data-editable="{{editable}}" style="background-color: #ff0000;" class="CalendarCell" id="{{member.user.username}}/{{year}}-{{month_num}}-{{day}}/TRUE" data-absence-type="S"></td>
-                            {% elif check_half_day == "A" %}
-                            <td data-editable="{{editable}}" style="background: linear-gradient(to right, #ffffff 50%, #ff0000 50% );" class="CalendarCell" id="{{member.user.username}}/{{year}}-{{month_num}}-{{day}}/TRUE" data-absence-type="A"></td>
-                            {% elif check_half_day == "M" %}
-                            <td data-editable="{{editable}}" style="background: linear-gradient(to right, #ff0000 50%, #ffffff 50%);" class="CalendarCell" id="{{member.user.username}}/{{year}}-{{month_num}}-{{day}}/TRUE" data-absence-type="M"></td>
-                            {% else %}
-                                {% if day in bank_hol and bank_holidays.enabled %}
-                                    <td data-editable="{{editable}}" style="background-color: {{ bank_holidays.colour }};" class="CalendarCell" id="{{member.user.username}}/{{year}}-{{month_num}}-{{day}}/FALSE"></td>
-                                {% elif day in weekend_list and weekends.enabled %}
-                                    <td data-editable="{{editable}}" style="background-color: {{ weekends.colour }};" class="CalendarCell" id="{{member.user.username}}/{{year}}-{{month_num}}-{{day}}/FALSE"></td>
-                                {% elif day in weekend_list and not weekends.enabled %}
-                                    <th style="display:none"> </th>
-                                {% else %}
-                                    <td data-editable="{{editable}}" class="CalendarCell" id="{{member.user.username}}/{{year}}-{{month_num}}-{{day}}/FALSE"></td>
-                                {% endif %}
-                            {% endif %}
-
-                        {% endfor %}
-
-                    </tr>
+                                        {% for day in day_range %}
+                                            {% check_absences absence_dates|get_key:member.user.username year month_num day as check_absence %}
+                                            {% check_absences recurring_absence_dates|get_key:member.user.username year month_num day as check_recurring_absence %}
+                                            {% check_half_day half_days_data|get_key:member.user.username year month_num day as check_half_day %}
+                                            {% if check_recurring_absence %}
+                                                <td data-editable="{{editable}}" style="background-color: #ffaa00;" class="CalendarCell" id="{{member.user.username}}/{{year}}-{{month_num}}-{{day}}/TRUE" data-absence-type="R"></td>
+                                            {% elif check_absence %}
+                                                <td data-editable="{{editable}}" style="background-color: #ff0000;" class="CalendarCell" id="{{member.user.username}}/{{year}}-{{month_num}}-{{day}}/TRUE" data-absence-type="S"></td>
+                                            {% elif check_half_day == "A" %}
+                                                <td data-editable="{{editable}}" style="background: linear-gradient(to right, #ffffff 50%, #ff0000 50% );" class="CalendarCell" id="{{member.user.username}}/{{year}}-{{month_num}}-{{day}}/TRUE" data-absence-type="A"></td>
+                                            {% elif check_half_day == "M" %}
+                                                <td data-editable="{{editable}}" style="background: linear-gradient(to right, #ff0000 50%, #ffffff 50%);" class="CalendarCell" id="{{member.user.username}}/{{year}}-{{month_num}}-{{day}}/TRUE" data-absence-type="M"></td>
+                                            {% else %}
+                                                {% if day in bank_hol and bank_holidays.enabled %}
+                                                    <td data-editable="{{editable}}" style="background-color: {{ bank_holidays.colour }};" class="CalendarCell" id="{{member.user.username}}/{{year}}-{{month_num}}-{{day}}/FALSE"></td>
+                                                {% elif day in weekend_list and weekends.enabled %}
+                                                    <td data-editable="{{editable}}" style="background-color: {{ weekends.colour }};" class="CalendarCell" id="{{member.user.username}}/{{year}}-{{month_num}}-{{day}}/FALSE"></td>
+                                                {% elif day in weekend_list and not weekends.enabled %}
+                                                    <th style="display:none"> </th>
+                                                {% else %}
+                                                    <td data-editable="{{editable}}" class="CalendarCell" id="{{member.user.username}}/{{year}}-{{month_num}}-{{day}}/FALSE"></td>
+                                                {% endif %}
+                                            {% endif %}
+                                        {% endfor %}
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
                     {% endfor %}
-                </tbody>
-            </table>
-            {% endfor %}
-        </div>
-        {% else %}
-        <div class="has-background-light box">
-            <div class="is-size-5 mb-3">
-                <span class="is-block is-size-5">You are not in any teams.</span>
-            </div>
-        </div>
-        {% endif %}
+                </div>
+            {% else %}
+                <div class="has-background-light box">
+                    <div class="is-size-5 mb-3">
+                        <span class="is-block is-size-5">You are not in any teams.</span>
+                    </div>
+                </div>
+            {% endif %}
+        {% endwith %}
+
         {% else %}
         <div class="has-background-light box">
             <div class="is-size-5 mb-3">

--- a/ap_src/templates/calendars/calendar_element.html
+++ b/ap_src/templates/calendars/calendar_element.html
@@ -50,8 +50,10 @@
             {% if number_of_teams > 0 %}
                 <div id="calendar-group">
                     {% for item in team_data %}
-                        <h1 class="is-size-5 has-text-weight-bold" id="title-{{ item.team.name }}">{{ item.team.name }}</h1>
-                        <a class="button is-link mx-1" href={% url 'api_team_calendar' id=item.team.id %}>View</a>
+                        {% if number_of_teams > 1 %}
+                            <h1 class="is-size-5 has-text-weight-bold" id="title-{{ item.team.name }}">{{ item.team.name }}</h1>
+                            <a class="button is-link mx-1" href={% url 'api_team_calendar' id=item.team.id %}>View</a>
+                        {% endif %}
                         <table class="table is-bordered is-striped" style="width: 100%" id="{{ item.team.name }}">
                             <tbody>
                                 {% for member in item.team.members %}

--- a/ap_src/templates/calendars/calendar_element.html
+++ b/ap_src/templates/calendars/calendar_element.html
@@ -51,10 +51,10 @@
                 <div id="calendar-group">
                     {% for item in team_data %}
                         {% if number_of_teams > 1 %}
-                            <h1 class="is-size-5 has-text-weight-bold" id="title-{{ item.team.name }}">
-                                {{ item.team.name }}
-                            </h1>
-                            <a class="button is-link mx-1" href={% url 'api_team_calendar' id=item.team.id %}>
+                            <a style="margin-bottom: 10px; gap: 20px;" class="button mx-1" href={% url 'api_team_calendar' id=item.team.id %}>
+                                <h1 class="is-size-5 has-text-weight-bold" id="title-{{ item.team.name }}">
+                                    {{ item.team.name }}
+                                </h1>
                                 <svg class="svg-inline--fa fa-home fa-w-18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l82.7 0L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3l0 82.7c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160c0-17.7-14.3-32-32-32L320 0zM80 32C35.8 32 0 67.8 0 112L0 432c0 44.2 35.8 80 80 80l320 0c44.2 0 80-35.8 80-80l0-112c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 112c0 8.8-7.2 16-16 16L80 448c-8.8 0-16-7.2-16-16l0-320c0-8.8 7.2-16 16-16l112 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L80 32z"/></svg>
                             </a>
                         {% endif %}

--- a/ap_src/templates/calendars/calendar_element.html
+++ b/ap_src/templates/calendars/calendar_element.html
@@ -51,8 +51,12 @@
                 <div id="calendar-group">
                     {% for item in team_data %}
                         {% if number_of_teams > 1 %}
-                            <h1 class="is-size-5 has-text-weight-bold" id="title-{{ item.team.name }}">{{ item.team.name }}</h1>
-                            <a class="button is-link mx-1" href={% url 'api_team_calendar' id=item.team.id %}>View</a>
+                            <h1 class="is-size-5 has-text-weight-bold" id="title-{{ item.team.name }}">
+                                {{ item.team.name }}
+                            </h1>
+                            <a class="button is-link mx-1" href={% url 'api_team_calendar' id=item.team.id %}>
+                                <svg class="svg-inline--fa fa-home fa-w-18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l82.7 0L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3l0 82.7c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160c0-17.7-14.3-32-32-32L320 0zM80 32C35.8 32 0 67.8 0 112L0 432c0 44.2 35.8 80 80 80l320 0c44.2 0 80-35.8 80-80l0-112c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 112c0 8.8-7.2 16-16 16L80 448c-8.8 0-16-7.2-16-16l0-320c0-8.8 7.2-16 16-16l112 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L80 32z"/></svg>
+                            </a>
                         {% endif %}
                         <table class="table is-bordered is-striped" style="width: 100%" id="{{ item.team.name }}">
                             <tbody>


### PR DESCRIPTION
Includes an button and external link that allows a user to navigate to a specific team from the main calendar.

However, there are other changes as well to the content, such as:

- Cleaning up the templating of the calendar component to be more readable
- Removing the external link button and title of a team if there is only one in the team data
- A new CSS class for the external link button