### PR TITLE
Add JS include back to clickable specific team calendar

### DIFF
--- a/ap_src/templates/calendars/specific_team_calendar.html
+++ b/ap_src/templates/calendars/specific_team_calendar.html
@@ -71,6 +71,6 @@
     <button class="modal-close is-large" aria-label="close"></button>
 </div>
 {% include 'calendars/calendar_element.html'%}
-
+<script src="{% static "js/api_calendar.js" %}" token="{{ csrf_token }}"></script>
 <script src="{% static 'js/teams.js' %}" apiURL="{{ url }}"></script>
 {% endblock %}


### PR DESCRIPTION
This should allow you to click on the specific team calendar (accessed by external link or view) to add absences.