### PR TITLE
Show success modal for leaving teams

### DIFF
--- a/ap_src/ap_app/static/js/teams.js
+++ b/ap_src/ap_app/static/js/teams.js
@@ -59,12 +59,32 @@ async function LeaveTeamAndRemovePermissions(teamId, username, token) {
             }
 
             const permissionsData = await permissionsResponse.json();
-            location.replace(location.origin + "/teams")
+            sessionStorage.setItem('showSuccessModal', 'true'); // Set flag to show success modal
+            location.reload(); // Reload the page to update the teams
         }
     } catch (err) {
         console.log(err);
     }
 }
+
+function showSuccessModal() {
+    const successModal = document.getElementById('successModal');
+    const closeSuccessButton = document.getElementById('closeSuccessButton');
+
+    successModal.classList.add('is-active');
+
+    closeSuccessButton.addEventListener('click', () => {
+        successModal.classList.remove('is-active');
+    });
+}
+
+// Check sessionStorage on page load to show success modal if necessary
+window.addEventListener('load', () => {
+    if (sessionStorage.getItem('showSuccessModal') === 'true') {
+        sessionStorage.removeItem('showSuccessModal'); // Clear the flag
+        showSuccessModal(); // Show the success modal
+    }
+});
 
 function JoinTeam(e, user, redirect) {
     var data = JSON.stringify({"username": user, "team": e.id})

--- a/ap_src/templates/teams/dashboard.html
+++ b/ap_src/templates/teams/dashboard.html
@@ -92,5 +92,20 @@
     <button class="modal-close is-large" aria-label="close"></button>
 </div>
 
+
+<div id="successModal" class="modal">
+    <div class="modal-background"></div>
+    <div class="modal-content">
+        <div class="box">
+            <h1 class="title">Success</h1>
+            <p>You have successfully left the team: {{team.name}} </p>
+            <div class="buttons is-right">
+                <button id="closeSuccessButton" class="button is-success">OK</button>
+            </div>
+        </div>
+    </div>
+    <button class="modal-close is-large" aria-label="close"></button>
+</div>
+
 <script src="{% static 'js/teams.js' %}" apiURL="{{ url }}"></script>
 {% endblock %}

--- a/ap_src/templates/teams/dashboard.html
+++ b/ap_src/templates/teams/dashboard.html
@@ -98,7 +98,7 @@
     <div class="modal-content">
         <div class="box">
             <h1 class="title">Success</h1>
-            <p>You have successfully left the team: {{team.name}} </p>
+            <p>You have successfully left the team.</p>
             <div class="buttons is-right">
                 <button id="closeSuccessButton" class="button is-success">OK</button>
             </div>


### PR DESCRIPTION
solve issue https://github.com/rropen/absense-planner/issues/311.
The solution will refresh the page after pressing leave on the confirm leave modal, before doing so a flag will be set that will prompt the success modal to appear after the page has been refreshed with the updated teams in the background. 