### PR TITLE
Made changes when hovering over calendar cells

### DIFF
--- a/ap_src/ap_app/static/css/dark.css
+++ b/ap_src/ap_app/static/css/dark.css
@@ -213,3 +213,15 @@ background-color: #3e4549;
 .external-link-title {
     color: white;
 }
+
+.CalendarCell[data-editable="True"]:hover {
+    background-color: #00000069; 
+}
+
+.CalendarCell[data-editable="True"] {
+    cursor: pointer;
+}
+
+.CalendarCell[data-editable="False"] {
+    cursor: not-allowed;
+}

--- a/ap_src/ap_app/static/css/light.css
+++ b/ap_src/ap_app/static/css/light.css
@@ -148,3 +148,15 @@
 #alert-ok-button:hover {
     background-color: darkgreen;
 }
+
+.CalendarCell[data-editable="True"]:hover {
+    background-color: #ff00001a; 
+}
+
+.CalendarCell[data-editable="True"] {
+    cursor: pointer;
+}
+
+.CalendarCell[data-editable="False"] {
+    cursor: not-allowed;
+}


### PR DESCRIPTION
Issue https://github.com/rropen/absense-planner/issues/386

Fixed. Now, when hovering over calendar cells to add absence, the cursor changes to finger click, and I also added a feauture, where, when you hover over other users cells, it doesn't allow you to click on it, and shows a prohibited cursor. And the cells darken once hovered over.

