### PR TITLE
Fixed the clickable calendar toggle issue, when hovering over the cells.

### DIFF
--- a/ap_src/ap_app/static/js/api_calendar.js
+++ b/ap_src/ap_app/static/js/api_calendar.js
@@ -69,14 +69,26 @@ document.addEventListener('click', function(e) {
 //Toggle clickable calendar on/off
 var calendarClickButton = document.getElementById("CalendarClick-Toggle")
 calendarClickButton.onclick = function() {
+    const calendarCells = document.querySelectorAll('.CalendarCell');
     if (calendarClickToggle == false) {
         calendarClickButton.style.borderColor = "green";
-        calendarClickToggle = true
+        calendarClickToggle = true;
+        calendarCells.forEach(cell => {
+            if (cell.id.startsWith("{{ user.username }}/")) {  
+                cell.dataset.editable = "True";
+            } else {
+                cell.dataset.editable = "False";
+            }
+        });
+        location.reload();
     } else {
         calendarClickButton.style.borderColor = "red";
-        calendarClickToggle = false
+        calendarClickToggle = false;
+        calendarCells.forEach(cell => {
+            cell.dataset.editable = "False";
+        });
     }
-}
+};
 
 function closeElement(e) {
     e.style.display = "none";


### PR DESCRIPTION
Issue https://github.com/rropen/absense-planner/issues/426

Fixed the issue with the clickable calendar being toggled off, it still shows the user that they can hover over cells. Now when the clickable calendar is toggled off, all of the cells show the prohibited cursor stopping the user from clicking the cells, and when toggled on, current user's cells remain clickable while others stay disabled.
