### PR TITLE
Consistent styling in join a team page

### DIFF
--- a/ap_src/templates/api_pages/teams.html
+++ b/ap_src/templates/api_pages/teams.html
@@ -8,6 +8,20 @@
         <div class="is-size-5 mb-3">
             <span class="is-block is-size-5 has-text-weight-bold">{{team.name}} 
                 <i class="fas fa-user-alt mx-2"></i>{{team.count}}</span>
+                <div class="mt-2">  
+                    {% if team.private %}
+                        <span class="tag is-info is-rounded">
+                            <i class="fas fa-lock"></i>&nbsp;Private
+                        </span>
+                    {% else %}
+                        <span class="tag is-info is-rounded">
+                            <i class="fas fa-unlock"></i>&nbsp;Public
+                        </span>
+                    {% endif %}
+                    <span class="tag is-dark is-rounded">
+                        <i class="fas fa-user-edit"></i>
+                    </span>
+                </div>
             <span class="is-block is-size-6">{{ team.description }}</span>
             <div class="is-grouped">
                 <button class="button is-success join-team-button" id="{{ team.id }}" onclick="JoinTeam(this, '{{ request.user.username }}', true)">Join Team</button>


### PR DESCRIPTION
Issue #411 

Added the tags/icons below the team name, to have the same styling as the joined teams page (where it shows private or public)

<img width="1077" alt="Screenshot 2025-02-21 at 10 20 53" src="https://github.com/user-attachments/assets/165d37e4-f551-4feb-b415-e27ae3d6de11" />
