### PR TITLE
Fixed the tab title

### DIFF
--- a/ap_src/templates/teams/create_team.html
+++ b/ap_src/templates/teams/create_team.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% load bulma_tags %}
-{% block title %}Create a Team{% endblock %}
+{% block title %}Create Team{% endblock %}
 {% load static %}
 {% block content %}
 

--- a/ap_src/templates/teams/create_team.html
+++ b/ap_src/templates/teams/create_team.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% load bulma_tags %}
-{% block title %}Join Team{% endblock %}
+{% block title %}Create a Team{% endblock %}
 {% load static %}
 {% block content %}
 


### PR DESCRIPTION
Issue #510

The tab title was not shown correctly when being on the creating a new team page. It was always showing "Join Team" instead of the correct title "Create a Team".
