### PR TITLE
Fixed the team leave bug, now it works as expected

### DIFF
--- a/ap_src/ap_app/static/js/teams.js
+++ b/ap_src/ap_app/static/js/teams.js
@@ -1,26 +1,35 @@
-function openLeaveTeamModal(teamId) {
-    const modal = document.getElementById('leaveTeamModal');
-    const confirmButton = $("#confirmLeaveButton");
-    const cancelButton = document.getElementById('cancelLeaveButton');
-    const modalCloseButton = document.querySelector('#leaveTeamModal .modal-close');
+function openLeaveTeamModal(teamId, teamName, userRole, memberCount) {
+    const leaveModal = document.getElementById('leaveTeamModal');
+    const deleteModal = document.getElementById('deleteTeamModal');
 
-    // Find hidden input used to send selected Team ID.
-    const teamIdInputElement = confirmButton.parent().children("[name='team_id']").eq(0)
+    document.getElementById('leaveTeamName').innerText = teamName;
+    document.getElementById('deleteTeamName').innerText = teamName;
 
-    modal.classList.add('is-active');
+    $('#leaveTeamInput').val(teamId);
+    $('#deleteTeamInput').val(teamId);
 
-    // Add the current Team ID to the form so it can be sent in the request when the confirm button is pressed.
-    teamIdInputElement.val(teamId);
+    if (userRole === 'Owner' && memberCount === 1) {
+        // Delete modal for when only member is owener
+        deleteModal.classList.add('is-active');
 
-    cancelButton.addEventListener('click', () => {
-        modal.classList.remove('is-active');
-        teamIdInputElement.val(""); // Reset Team ID input
-    });
+        document.getElementById('cancelDeleteButton').onclick = () => {
+            deleteModal.classList.remove('is-active');
+        };
+        document.querySelector('#deleteTeamModal .modal-close').onclick = () => {
+            deleteModal.classList.remove('is-active');
+        };
 
-    modalCloseButton.addEventListener('click', () => {
-        modal.classList.remove('is-active');
-        teamIdInputElement.val("");
-    });
+    } else {
+        // Leave modal if not the only member
+        leaveModal.classList.add('is-active');
+
+        document.getElementById('cancelLeaveButton').onclick = () => {
+            leaveModal.classList.remove('is-active');
+        };
+        document.querySelector('#leaveTeamModal .modal-close').onclick = () => {
+            leaveModal.classList.remove('is-active');
+        };
+    }
 }
 
 function showSuccessModal() {

--- a/ap_src/templates/calendars/specific_team_calendar.html
+++ b/ap_src/templates/calendars/specific_team_calendar.html
@@ -40,7 +40,12 @@
                 {% endif %}
                 <button class="button is-danger is-outlined mx-1 leave-team-button"
                         id="{{ id }}"
-                        onclick="openLeaveTeamModal('{{ id }}')"
+                        onclick="openLeaveTeamModal(
+                            '{{ id }}',
+                            '{{ team_index.team.name|escapejs }}',
+                            '{{ user_data.role_info.role }}',
+                            {{ team_index.team.members|length }}
+                        )"
                 >
                     Leave
                 </button>

--- a/ap_src/templates/teams/dashboard.html
+++ b/ap_src/templates/teams/dashboard.html
@@ -92,8 +92,7 @@
             <a class="button is-info mx-1" href={% url 'edit_team' id=team.team.id %}>Edit</a>
             {% endif %}
             <button class="button is-danger mx-1 leave-team-button"
-                    id="{{ team.team.id }}"
-                    onclick="openLeaveTeamModal('{{ team.team.id }}')"
+                    onclick="openLeaveTeamModal('{{ team.team.id }}', '{{ team.team.name }}', '{{ team.role.role }}', {{ team.team.members|length }})"
             >
                 Leave
             </button>

--- a/ap_src/templates/teams/elements/leave_team_modal.html
+++ b/ap_src/templates/teams/elements/leave_team_modal.html
@@ -4,11 +4,11 @@
     <div class="modal-content">
         <div class="box">
             <h1 class="title">Confirm Leave</h1>
-            <p>Are you sure you want to leave this team?</p>
+            <p>Are you sure you want to leave <strong id="leaveTeamName"></strong>?</p>
             <div class="buttons is-right">
-                <form action="{% url "leave_team" %}" method="POST">
+                <form id="leaveTeamForm" action="{% url 'leave_team' %}" method="POST">
                     {% csrf_token %}
-                    <input type="hidden" name="team_id" value="">
+                    <input id="leaveTeamInput" type="hidden" name="team_id" value="">
                     <button id="confirmLeaveButton" class="button is-danger" type="submit">Leave</button>
                 </form>
                 <button id="cancelLeaveButton" class="button">Cancel</button>
@@ -16,4 +16,24 @@
         </div>
     </div>
     <button class="modal-close is-large" aria-label="close"></button>
+</div>
+
+{# Delete Team modal for when owner only member #}
+<div id="deleteTeamModal" class="modal">
+    <div class="modal-background"></div>
+    <div class="modal-content">
+        <div class="box">
+            <h1 class="title">Delete Team</h1>
+            <p>You are the only member of <strong id="deleteTeamName"></strong>. Would you like to delete it?</p>
+            <div class="buttons is-right">
+                <form id="deleteTeamForm" action="{% url 'delete_team' %}" method="POST">
+                    {% csrf_token %}
+                    <input id="deleteTeamInput" type="hidden" name="team_id" value="">
+                    <button id="confirmDeleteButton" class="button is-danger" type="submit">Delete</button>
+                </form>
+                <button id="cancelDeleteButton" class="button" type="button">Cancel</button>
+            </div>
+        </div>
+    </div>
+    <button class="modal-close is-large" aria-label="close" onclick="closeDeleteTeamModal()"></button>
 </div>


### PR DESCRIPTION
Issue #282 
Changes I made:

**teams.js:**

- Did some changes on the openLeaveTeamModal() to accept team name + member count status.
- Shows different text and buttons in the modal depending on whether the user is the only member (delete) or not (leave)
- Simplified some logic by removin jQuery DOM stuff to keep it clean and readable
(Still handles the success modal stuff the same way)

**leave_team_modal.html:**

- Changes the modal into a multipurpose one, that will show a leave or delete prompt depending on the team situation.
- Also added a thing where it shows the team name in the modal for clarity

**dashboard.html:**

- Updated the leave buton to call openLeaveTeamModal(teamId, teamName, isOnlyMember) and pass extra data to the modal
- passed the team.team.name and a check for whether the team only has one member (just so the modal knows when to show the delete option instead)


