### PR TITLE
AP: Remove extra vertical scrollbar in calendar element

### DIFF
--- a/ap_src/ap_app/static/css/layout.css
+++ b/ap_src/ap_app/static/css/layout.css
@@ -122,11 +122,6 @@ footer {
     border-width: 2px;
 }
 
-.calendar-group {
-    overflow: auto;
-    height: 75vh;
-}
-
 .dates-table {
     width: 100%;
     position: sticky;


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/622dc013-11b1-4038-949a-8c85d4c42a1a)

After:

![image](https://github.com/user-attachments/assets/d217599b-eea8-47d8-af39-7234adb92f85)
