### PR TITLE
Add requirements to help users create a team

### DIFF
--- a/ap_src/templates/teams/create_team.html
+++ b/ap_src/templates/teams/create_team.html
@@ -22,9 +22,17 @@
         
 
         {{ form | bulma }}
-        
-    <h2 class="description dText"><b>Please enter a minimum of 3 characters for each box.<b></h2>
-    <h2 class="description dText"><b>Please avoid using personal information in the description as it will be seen by non team members.<b></h2>
+
+    <div id="notif-info" class="notification is-info">
+    <button class="delete" type="button"></button>
+    Please enter a minimum of 3 characters for the team name and team description.
+    </div>
+
+    <div id="notif-warning" class="notification is-warning">
+    <button class="delete" type="button"></button>
+    Please avoid using personal information in the description as it will be seen by non team members.
+    </div>
+
     <input type="hidden" name="origin_application" value="Absence Planner">
     <label id="label_button" class="button is-primary" disabled>
         Submit

--- a/ap_src/templates/teams/create_team.html
+++ b/ap_src/templates/teams/create_team.html
@@ -25,7 +25,7 @@
 
     <div id="notif-info" class="notification is-info">
     <button class="delete" type="button"></button>
-    Please enter a minimum of 3 characters for the team name and team description.
+    Enter a minimum of 3 characters for the team name and team description.
     </div>
 
     <div id="notif-warning" class="notification is-warning">

--- a/ap_src/templates/teams/create_team.html
+++ b/ap_src/templates/teams/create_team.html
@@ -22,7 +22,8 @@
         
 
         {{ form | bulma }}
-
+        
+    <h2 class="description dText"><b>Please enter a minimum of 3 characters for each box.<b></h2>
     <h2 class="description dText"><b>Please avoid using personal information in the description as it will be seen by non team members.<b></h2>
     <input type="hidden" name="origin_application" value="Absence Planner">
     <label id="label_button" class="button is-primary" disabled>

--- a/ap_src/templates/teams/edit_team.html
+++ b/ap_src/templates/teams/edit_team.html
@@ -18,10 +18,19 @@
                     <form class="py-1" method="POST" action="">
                         {% csrf_token %}
                         {{ form | bulma }}
-                        <input class="button is-link is-fullwidth" type="submit" value="Submit" />
+
+                        <input class="button is-link is-fullwidth button is-success" type="submit" value="Submit" />
                     </form><br />
                     <button class="button is-danger" onclick="openDeleteTeamModal(this)" id="{{ team.id }}" type="button">Delete Team</button>
                 </div>
+                        <div id="notif-info" class="notification is-info">
+                        <button class="delete" type="button"></button>
+                        Please enter a minimum of 3 characters for the team name and team description.
+                        </div>
+                        <div id="notif-warning" class="notification is-warning">
+                        <button class="delete" type="button"></button>
+                        Please avoid using personal information in the description as it will be seen by non team members.
+                        </div>
             </div>
             <div class="column">
                 <div class="has-background-light box is-fullheight">

--- a/ap_src/templates/teams/edit_team.html
+++ b/ap_src/templates/teams/edit_team.html
@@ -21,8 +21,7 @@
 
                         <input class="button is-link is-fullwidth button is-success" type="submit" value="Submit" />
                     </form><br />
-                    <button class="button is-danger" onclick="openDeleteTeamModal(this)" id="{{ team.id }}" type="button">Delete Team</button>
-                </div>
+                    <button class="button is-danger mb-5" onclick="openDeleteTeamModal(this)" id="{{ team.id }}" type="button">Delete Team</button>
                         <div id="notif-info" class="notification is-info">
                         <button class="delete" type="button"></button>
                         Enter a minimum of 3 characters for the team name and team description.
@@ -31,6 +30,7 @@
                         <button class="delete" type="button"></button>
                         Please avoid using personal information in the description as it will be seen by non team members.
                         </div>
+                </div>
             </div>
             <div class="column">
                 <div class="has-background-light box is-fullheight">

--- a/ap_src/templates/teams/edit_team.html
+++ b/ap_src/templates/teams/edit_team.html
@@ -25,7 +25,7 @@
                 </div>
                         <div id="notif-info" class="notification is-info">
                         <button class="delete" type="button"></button>
-                        Please enter a minimum of 3 characters for the team name and team description.
+                        Enter a minimum of 3 characters for the team name and team description.
                         </div>
                         <div id="notif-warning" class="notification is-warning">
                         <button class="delete" type="button"></button>


### PR DESCRIPTION
Issue Number: #582

The submit button is disabled until the user enters a minimum of 3 characters in both the title and the description box so a message was added to help the user in their creation of a team. 

Before:
![image](https://github.com/user-attachments/assets/402bf6c1-497e-4825-a059-9fc80896e886)

After:
![image](https://github.com/user-attachments/assets/7f64972a-3988-495c-86e7-4fa6fc163d44)
