### PR TITLE
darkmode dropdown

### DIFF
--- a/ap_src/ap_app/static/css/dark.css
+++ b/ap_src/ap_app/static/css/dark.css
@@ -110,6 +110,14 @@ h3 {
     color: white;
 }
 
+header, .navbar {
+  background-color: #121212 !important;
+  color: rgb(0, 0, 0) !important;
+}
+
+header a, .navbar a {
+  color: rgb(0, 0, 0) !important;
+}
 
 
 /* End of basic */

--- a/ap_src/ap_app/static/css/dark.css
+++ b/ap_src/ap_app/static/css/dark.css
@@ -110,7 +110,7 @@ h3 {
     color: white;
 }
 
-header, .navbar {
+.navbar-dropdown > .navbar-item {
   background-color: #121212 !important;
   color: rgb(0, 0, 0) !important;
 }


### PR DESCRIPTION
#619 

make dropdown text and login readable and match darkmode

before:
<img width="1414" alt="Screenshot 2025-06-18 at 11 51 55" src="https://github.com/user-attachments/assets/e4b26fd9-ace4-4f64-8f58-750c995b73ad" />

after:
<img width="1412" alt="Screenshot 2025-06-18 at 11 51 03" src="https://github.com/user-attachments/assets/3ccd13ae-5914-4c8f-999a-2d6a9006c53d" />
