### PR TITLE
Added title on teams page

### DIFF
--- a/ap_src/templates/teams/dashboard.html
+++ b/ap_src/templates/teams/dashboard.html
@@ -12,6 +12,9 @@
         </div>
     </div>
     {% else %}
+    <div class="container" style="margin-top: 1rem; margin-bottom: 2rem;">
+        <h1 class="title has-text-centered dText">Your Teams</h1>
+    </div>
     {% for team in teams %}
     <div class="container has-background-light box darkInput" style="margin-top: 2rem;">
         <div class="is-size-5 mb-3">


### PR DESCRIPTION
Issue #624

Added a title on the teams page for consistency, looks better now too.

![image](https://github.com/user-attachments/assets/ceb4f5d7-8cfd-4c7f-97e8-69eb1dc63176)

