### PR TITLE
Fixed calendar table

### DIFF
--- a/ap_src/templates/calendars/elements/calendar_element.html
+++ b/ap_src/templates/calendars/elements/calendar_element.html
@@ -11,7 +11,7 @@
 <section class="section pt-0">
     <div class="table-container calendar-group nav-bar-padding">
         {% if team_data %}
-        <table class="table is-bordered is-striped dates-table" style="box-shadow: 5px 5px 5px" id="{{ item.team.name }}">
+        <table class="table is-bordered is-striped dates-table" style="box-shadow: 5px 5px 5px width: 100%" id="{{ item.team.name }}">
             <thead>
                 <tr class="is-flex">
                     <td data-editable="{{editable}}" style="background-color: rgb(0, 169, 236); color: rgb(255, 255, 255);background-color: {{ weekends.offset}} !important;" class="header-label-cell CalendarCell has-text-centered p-0 is-vcentered has-text-white days-cell">Days</th>


### PR DESCRIPTION
When a user would magnify out of the home page where the calendar and the table are with the dates, a white bar would appear to the right of the table, which also had a shadow and would increase in width the more you zoom out, so that is now fixed.