### PR TITLE
Changed the design of the calendar key

### DIFF
--- a/ap_src/templates/calendars/all_teams_calendar.html
+++ b/ap_src/templates/calendars/all_teams_calendar.html
@@ -26,19 +26,15 @@
             </script>
         </span>
 
-
-        <div style="margin-top: 60px; padding: 10px 15px; border: 1px solid #ccc; border-radius: 6px; background-color: #f9f9f9; max-width: 350px;">
-            <p style="margin: 5px 0;">
-                <span style="display: inline-block; width: 15px; height: 15px; background-color: white; border: 1px solid black; margin-right: 8px; vertical-align: middle;"></span>
-                No Absences
-            </p>
-            <p style="margin: 5px 0;">
-                <span style="display: inline-block; width: 15px; height: 15px; background-color: red; border: 1px solid black; margin-right: 8px; vertical-align: middle;"></span>
-                Absence Booked
-            </p>
-            <p style="margin: 5px 0;">
-                <span style="display: inline-block; width: 15px; height: 15px; background-color: orange; border: 1px solid black; margin-right: 8px; vertical-align: middle;"></span>
-                Recurring Absence
+        <div class="px-4 py-2" style="border: 1px solid #ccc; border-radius: 6px; background-color: #f9f9f9; max-width: fit-content;">
+            <h1 class="mr-2" style="font-weight: bold; font-size: 1.2rem">Key:</h1>
+            <p style="pb-1">
+                <span class="mr-1" style="display: inline-block; width: 15px; height: 15px; background-color: white; border: 1px solid black; vertical-align: middle;"></span>
+                <span class="pr-3" style="vertical-align: middle"> No Absences </span>
+                <span class="mr-1" style="display: inline-block; width: 15px; height: 15px; background-color: red; border: 1px solid black; vertical-align: middle;"></span>
+                <span class="pr-3" style="vertical-align: middle"> Absence Booked </span>
+                <span class="mr-1" style="display: inline-block; width: 15px; height: 15px; background-color: orange; border: 1px solid black; vertical-align: middle;"></span>
+                <span style="vertical-align: middle"> Reccuring Absence </span>
             </p>
         </div>
 


### PR DESCRIPTION
The calendar key was just a colour box and text next to it going down horizontally, but now I changed it to be 2 vertical rows, along with a title of the word "Key", so that users know what the colour box and the text mean, as well as making it look a bit better in terms of aesthetics.