### PR TITLE
Fixed issues with calendar modals.

### DIFF
--- a/ap_src/templates/ap_app/elements/confirmation_modal.html
+++ b/ap_src/templates/ap_app/elements/confirmation_modal.html
@@ -7,7 +7,7 @@
         {% else %}
             <header class="modal-card-head darkBackground" style="height: 10vh;">
         {% endif %}
-        <p class="modal-card-title title darkBackground" style="color:white; margin: 2vh;">{{ title }}</p>
+        <p class="modal-card-title title darkBackground" style="margin: 2vh;">{{ title }}</p>
     </header>
     <section class="modal-card-body darkBackground">
         {% if type == 'remove' %}
@@ -39,7 +39,8 @@
         <button class="button has-background-danger has-text-white" onclick="closeModal('{{ type }}')">Close</button>
     {% elif type == 'half' %}
         <button class="button has-background-primary has-text-white" id="morningBTN" style="margin-right: 1vw;">Morning</button>
-        <button class="button has-background-primary has-text-white" id="afternoonBTN">Afternoon</button>
+        <button class="button has-background-primary has-text-white" id="afternoonBTN" style="margin-right: 1vw;">Afternoon</button>
+        <button class="button has-background-danger has-text-white" onclick="closeModal('{{ type }}')">Cancel</button>
     {% endif %}
 </div>
 </div>


### PR DESCRIPTION
The titles of the modals beforehand were white, so they were not visible to the users when opened up.
They are now black and clear for the user to see what the modal is about.
I also added a "Cancel" button in one of the modals, else there was no way for the user to go back if they didn't want to make any changes.